### PR TITLE
tx fee adjusment fixes

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -33,8 +33,8 @@ static const unsigned int MAX_BLOCK_SIZE = 1000000;
 static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2;
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 static const unsigned int MAX_ORPHAN_TRANSACTIONS = MAX_BLOCK_SIZE/100;
-static const int64 MIN_TX_FEE = 0;
-static const int64 DUST_LIMIT = 1000000;
+static const int64 MIN_TX_FEE = 10000000;
+static const int64 DUST_LIMIT = 10000000;
 static const int64 MIN_RELAY_TX_FEE = MIN_TX_FEE;
 static const int64 MAX_MONEY = 10000000000 * COIN;
 inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }


### PR DESCRIPTION
Tested actual 0 tx fee. Transaction times skyrocketed. Setting it back to what it was originally. Most transactions are still free but super small and super large transactions now generate a fee per the original code.